### PR TITLE
[UI]: Generate Link button - Overriding External Styles from Color Picker Chrome Extension

### DIFF
--- a/style.css
+++ b/style.css
@@ -47,10 +47,12 @@ input.input-error {
   font-size: 0.8rem;
   display: none;
 }
+
 .mob-container {
   display: flex;
   gap: 4px;
 }
+
 .mob-code {
   display: flex;
 }
@@ -72,6 +74,30 @@ input.input-error {
   border-color: #13c703;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px #13c703;
 }
+
+/* #mybtn override for chrome extension injected stylesheet */
+#mybtn {
+  display: inline-block;
+  padding: 6px 12px;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #198754;
+  border-color: #198754;
+  font-size: 1rem;
+  border-radius: 0.25rem;
+  border-width: 0;
+  margin: 0;
+  border-image: none;
+  height: 100%;
+  width: 7.6rem;
+}
+#mybtn:hover {
+  color: #fff;
+  background-color: #146a42;
+  border-color: #146a42;
+}
+
 
 /* Link */
 


### PR DESCRIPTION
**Problem:**
- I observed that the Color Picker Chrome extension was injecting styles into the webpage, which led to conflicts and visual discrepancies, especially with our "Generate Link" button.
- Existing styles were getting overridden due to higher specificity or later loading order of the extension's styles.
- There were potential namespace clashes due to the extension using class or ID names that match those on our web page.

**Solution:**
- I've added css for #mybtn in styles.css, which will override the styling by any chrome extension which accesses Generate Link button by same ID.

closes #68