### PR TITLE
Fix generate link button width

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,7 +91,6 @@ input.input-error {
   margin: 0;
   border-image: none;
   height: 100%;
-  width: 7.6rem;
 }
 #mybtn:hover {
   color: #fff;


### PR DESCRIPTION
Currently button text is broken into two lines for all screen size

<img width="1516" alt="image" src="https://github.com/amittri1025/Whatsapp-Link-Gen/assets/44529643/70b42777-db11-4c89-b164-eae6fc291170">

<img width="422" alt="image" src="https://github.com/amittri1025/Whatsapp-Link-Gen/assets/44529643/fce9314e-ad64-49b2-93cd-277c727d3309">


**Fix:** Removing hardcoded width in the button


<img width="1536" alt="image" src="https://github.com/amittri1025/Whatsapp-Link-Gen/assets/44529643/7ec893dd-3124-4acc-aab8-2ffb40b53af9">

<img width="408" alt="image" src="https://github.com/amittri1025/Whatsapp-Link-Gen/assets/44529643/bb2be98d-9471-413e-8d4e-609fdd8e214b">
